### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ WORKDIR /app
 COPY pyproject.toml /app/pyproject.toml
 COPY poetry.lock /app/poetry.lock
 
-RUN pip install --upgrade pip \
-  && pip install poetry \
+RUN pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir poetry \
   && poetry install --no-dev \
   && apk del binutils libmagic file libgcc gcc musl-dev libc-dev g++ make fortify-headers build-base libffi-dev openssl-dev
 


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 478.49 MB
* Image size after repair: 458.55 MB
* Difference: 19.94 MB (4.17%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,